### PR TITLE
Fix syntax error in message template

### DIFF
--- a/templates/components/status-messages.html.twig
+++ b/templates/components/status-messages.html.twig
@@ -34,10 +34,10 @@
       set type_class = [
         'status-messages',
         'status-messages--' + type,
-      ];
-
-      set type_attributes = attributes.removeAttribute('class').addClass(type_class)
+      ]
     %}
+
+    {% set type_attributes = attributes.removeAttribute('class').addClass(type_class) %}
 
     <div role="contentinfo" aria-label="{{ status_headings[type] }}"{{ type_attributes|without('role', 'aria-label') }}>
       {% if type == 'error' %}


### PR DESCRIPTION
Twig didn't like the `;` ending when setting the `type_class` variable. I don't know if it's possible to have multiple `set` statements within the same `{% %}` but I separated them to fix the error.

Please let me know if there's another way :)